### PR TITLE
Disable coverage as a default from jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   },
   "jest": {
     "coverageDirectory": "./coverage",
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "<rootDir>/src/**/*.js"
     ],


### PR DESCRIPTION
This PR removes coverage as a default option when running jest. This is to keep stdout clean when running jest in watch mode.